### PR TITLE
Move appTitle to content block

### DIFF
--- a/app/components/static-page.hbs
+++ b/app/components/static-page.hbs
@@ -10,8 +10,8 @@
     role="presentation"
   />
 </AuContentHeader>
-<div style="min-height:63vh">
-{{yield}}
+<div class="flex-grow">
+  {{yield}}
 </div>
 <AuMainFooter>
   <AuHeading @level="3" @skin="4">

--- a/app/components/static-page.hbs
+++ b/app/components/static-page.hbs
@@ -1,6 +1,6 @@
 <AuContentHeader
   @titlePartOne="Vlaanderen"
-  @titlePartTwo={{(concat "is het " (config "maintenance.appTitle"))}}
+  @titlePartTwo="is lokaal bestuur"
 >
   <img
     sizes="50vw"

--- a/app/router.js
+++ b/app/router.js
@@ -7,7 +7,7 @@ export default class Router extends EmberRouter {
 }
 
 Router.map(function () {
-  this.route('contact', { path: '/contact' });
+  this.route('contact');
   this.route('legal', { path: '/legaal' }, function () {
     this.route('disclaimer');
     this.route('cookiestatement', { path: '/cookieverklaring' });
@@ -20,5 +20,4 @@ Router.map(function () {
   this.route('redirect', {
     path: '/*wildcard',
   });
-
 });

--- a/app/routes/redirect.js
+++ b/app/routes/redirect.js
@@ -6,6 +6,5 @@ export default class RedirectRoute extends Route {
 
   async beforeModel() {
     return this.router.replaceWith('index');
-
   }
 }

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -1,0 +1,5 @@
+
+
+.flex-grow {
+  flex-grow: 1
+}

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -110,6 +110,7 @@
 @import "appuniversum/u-spacings";
 @import "appuniversum/u-visible";
 @import "appuniversum/u-widths";
+@import "appuniversum/u-flex";
 
 // TEMPORARY HACKS AND QUICKFIXES
 @import 'shame';

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -2,12 +2,6 @@
 
 <AppHeader />
 
-<main id="main" class="au-c-main-container">
-  <div
-    class="au-c-main-container__content"
-    id="content"
-    tabindex="-1"
-  >
+<main id="main" class="au-c-main-container au-u-flex--column">
     {{outlet}}
-  </div>
 </main>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -1,11 +1,10 @@
-
 <StaticPage>
   <section class="au-o-layout au-o-region-large">
     <div class="au-o-grid au-o-grid--small">
-      <div class="au-o-grid__item au-u-3-4@small au-u-1-2@medium">
+      <div class="au-o-grid__item">
         <AuContent @skin="large">
+          <h1>{{config "maintenance.appTitle"}}</h1>
           <p class="au-c-heading au-c-heading--4">{{config "maintenance.message"}}</p>
-
         </AuContent>
       </div>
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -7,9 +7,9 @@ module.exports = function (environment) {
     rootURL: '/',
     locationType: 'auto',
     maintenance: {
-      message: "{{MAINTENANCE_MESSAGE}}",
-      appTitle: "{{MAINTENANCE_APP_TITLE}}",
-      appUrl: "{{MAINTENANCE_APP_URL}}"
+      message: '{{MAINTENANCE_MESSAGE}}',
+      appTitle: '{{MAINTENANCE_APP_TITLE}}',
+      appUrl: '{{MAINTENANCE_APP_URL}}',
     },
     EmberENV: {
       FEATURES: {
@@ -26,7 +26,6 @@ module.exports = function (environment) {
       // Here you can pass flags/options to your application instance
       // when it is created
     },
-
   };
 
   if (environment === 'development') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8495,9 +8495,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001358",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001358.tgz",
-      "integrity": "sha512-hvp8PSRymk85R20bsDra7ZTCpSVGN/PAz9pSAjPSjKC+rNmnUk5vCRgJwiTT/O4feQ/yu/drvZYpKxxhbFuChw==",
+      "version": "1.0.30001565",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001565.tgz",
+      "integrity": "sha512-xrE//a3O7TP0vaJ8ikzkD2c2NgcVUvsEe2IvFTntV4Yd1Z9FVzh+gW+enX96L0psrbaFMcVcH2l90xNuGDWc8w==",
       "dev": true,
       "funding": [
         {
@@ -8507,6 +8507,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -35386,9 +35390,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001358",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001358.tgz",
-      "integrity": "sha512-hvp8PSRymk85R20bsDra7ZTCpSVGN/PAz9pSAjPSjKC+rNmnUk5vCRgJwiTT/O4feQ/yu/drvZYpKxxhbFuChw==",
+      "version": "1.0.30001565",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001565.tgz",
+      "integrity": "sha512-xrE//a3O7TP0vaJ8ikzkD2c2NgcVUvsEe2IvFTntV4Yd1Z9FVzh+gW+enX96L0psrbaFMcVcH2l90xNuGDWc8w==",
       "dev": true
     },
     "capture-exit": {


### PR DESCRIPTION
In current solution the text in the header would be "Vlaanderen is **het** Lokale Producten- en Dienstencatalogus".
This is language wise not correct.

Proposed solution:
- always show "Vlaanderen is lokaal bestuur" this is the same text as in loket
- maintenance.appTitle will show above maintenance.message in content
- EXTRA:  title and message are full width instead of half width

![image](https://github.com/lblod/frontend-generic-maintenance/assets/47595987/1ca489d7-4379-4ba3-a100-7b5ab2f503b5)

example with ENV variables filled in 
![image](https://github.com/lblod/frontend-generic-maintenance/assets/47595987/25c4c641-efea-4e5f-9843-d3e904385cf2)

